### PR TITLE
Fix output file overwrite

### DIFF
--- a/CAppSrtMerge/CAppSrtMerge.csproj
+++ b/CAppSrtMerge/CAppSrtMerge.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>1.0.1.0</Version>
+    <Version>1.0.2.0</Version>
   </PropertyGroup>
 
 </Project>

--- a/LibSrtMerge.Tests/TestCommandLineInterface/TestCommandLine.cs
+++ b/LibSrtMerge.Tests/TestCommandLineInterface/TestCommandLine.cs
@@ -15,7 +15,7 @@ namespace LibSrtMerge
             var fsMock = new Mock<IFileSystem>(MockBehavior.Strict);
             fsMock.Setup(fs => fs.File.OpenRead(It.IsAny<string>())).Returns<string>(Tests.TestParser.GetResourceStream);
             var output = new MemoryStream();
-            fsMock.Setup(fs => fs.File.OpenWrite("output.srt")).Returns(output);
+            fsMock.Setup(fs => fs.File.Open("output.srt", FileMode.Create)).Returns(output);
 
             var cli = new CommandLineInterface()
             {

--- a/LibSrtMerge/CommandLineInterface.cs
+++ b/LibSrtMerge/CommandLineInterface.cs
@@ -30,7 +30,7 @@ namespace LibSrtMerge
 
                     var result = merger.MergeSubtitles(s1, s2);
 
-                    using (var output = FileSystem.File.OpenWrite(outputPath))
+                    using (var output = FileSystem.File.Open(outputPath, FileMode.Create))
                     {
                         merger.WriteStream(output, result);
                     }

--- a/LibSrtMerge/FileInterface.cs
+++ b/LibSrtMerge/FileInterface.cs
@@ -4,6 +4,11 @@ namespace LibSrtMerge
 {
     internal class FileInterface : IFileInterface
     {
+        Stream IFileInterface.Open(string path, FileMode mode)
+        {
+            return File.Open(path, mode);
+        }
+
         Stream IFileInterface.OpenRead(string path)
         {
             return File.OpenRead(path);

--- a/LibSrtMerge/IFileInterface.cs
+++ b/LibSrtMerge/IFileInterface.cs
@@ -7,5 +7,6 @@ namespace LibSrtMerge
     {
         Stream OpenRead(string path);
         Stream OpenWrite(string path);
+        Stream Open(string path, FileMode mode);
     }
 }


### PR DESCRIPTION
When the output file is opened, it must be truncated/overwritten, if it already exists

- add interface methods in `IFileSystem` to support opening file in `create` mode.
- adapt `CommandLine` to open file in `create` mode
- fix test
- bump version